### PR TITLE
Fix sub rows from overwriting the model cache of the parent

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -3275,7 +3275,7 @@ var DobyGrid = function (options) {
 			if (data.rows) {
 				var child_row_idxs = _.chain(data.rows)
 					.map(function (row) {
-						cache.modelsById[id] = row;
+						cache.modelsById[row[grid.options.idProperty]] = row;
 						return cache.indexById[row[grid.options.idProperty]];
 					})
 					.compact()


### PR DESCRIPTION
The modified line appears to be using the parent ID to recursively write each sub row into the model cache, overwriting the parent and possibly some of the sub rows. This in itself doesn't cause any issues, but if you try to use remove() on the parent ID after expanding a child row, instead of removing the parent (and all children) from the table, it removes the last item in the table, because the get() call in remove() will always return -1 from its indexOf() check - thus, causing a negative slice from the items array. Using the same reference as the indexById return the line below resolves the problem.